### PR TITLE
fix: use absolute $HOME paths in home::symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ TODO: Add a short summary of this module.
 - `p6df::modules::go::home::symlink()`
 - `p6df::modules::go::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::go::langs()`
 - `p6df::modules::go::vscodes()`
 - `p6df::modules::go::vscodes::config()`

--- a/init.zsh
+++ b/init.zsh
@@ -74,7 +74,7 @@ p6df::modules::go::home::symlink() {
     p6_file_symlink "$P6_DFZ_SRC_DIR" "$GOPATH/src"
   fi
 
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-go/share/.goenvrc" ".goenvrc"
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-go/share/.goenvrc" "$HOME/.goenvrc"
 
   p6_return_void
 }


### PR DESCRIPTION
Symlink targets were using relative paths (e.g. `.aws`) instead of absolute `$HOME/.aws`. Fixes symlinks when not run from $HOME.