### PR TITLE
feat: add home::symlinks() for claude skills

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -84,6 +84,21 @@ p6df::modules::go::home::symlink() {
 ######################################################################
 #<
 #
+# Function: p6df::modules::go::home::symlinks()
+#
+#  Environment:	 HOME P6_DFZ_SRC_DIR
+#>
+######################################################################
+p6df::modules::go::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/smallnest/goskills"  "$HOME/.claude/skills/goskills"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
 # Function: p6df::modules::go::langs()
 #
 #>


### PR DESCRIPTION
## Summary

- Adds `home::symlinks()` function to symlink Claude Code skills into `~/.claude/skills/`

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)