### PR TITLE
chore(go): merge home::symlink into home::symlinks

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -67,7 +67,7 @@ EOF
 #
 # Function: p6df::modules::go::home::symlinks()
 #
-#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#  Environment:	 HOME GOPATH P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
 p6df::modules::go::home::symlinks() {

--- a/init.zsh
+++ b/init.zsh
@@ -72,6 +72,10 @@ EOF
 ######################################################################
 p6df::modules::go::home::symlinks() {
 
+  if p6_string_blank_NOT "$GOPATH"; then
+    p6_file_symlink "$P6_DFZ_SRC_DIR" "$GOPATH/src"
+  fi
+
   p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-go/share/.goenvrc" "$HOME/.goenvrc"
 
   p6_file_symlink "$P6_DFZ_SRC_DIR/smallnest/goskills"  "$HOME/.claude/skills/goskills"

--- a/init.zsh
+++ b/init.zsh
@@ -65,31 +65,14 @@ EOF
 ######################################################################
 #<
 #
-# Function: p6df::modules::go::home::symlink()
-#
-#  Environment:	 GOPATH P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-p6df::modules::go::home::symlink() {
-
-  if p6_string_blank_NOT "$GOPATH"; then
-    p6_file_symlink "$P6_DFZ_SRC_DIR" "$GOPATH/src"
-  fi
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-go/share/.goenvrc" "$HOME/.goenvrc"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
 # Function: p6df::modules::go::home::symlinks()
 #
-#  Environment:	 HOME P6_DFZ_SRC_DIR
+#  Environment:	 HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
 ######################################################################
 p6df::modules::go::home::symlinks() {
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-go/share/.goenvrc" "$HOME/.goenvrc"
 
   p6_file_symlink "$P6_DFZ_SRC_DIR/smallnest/goskills"  "$HOME/.claude/skills/goskills"
 


### PR DESCRIPTION
## What
Merge the dotfile symlink from the singular (never-called) `home::symlink` function into the plural (auto-called) `home::symlinks` function. Delete the singular function.

## Why
The p6df-core framework dispatches `home::symlinks` (plural) via `p6df::core::internal::recurse`. The singular `home::symlink` function was never auto-called — `~/.goenvrc` only existed as a symlink from prior manual creation.

## Test plan
- `p6df home symlinks` recreates `~/.goenvrc` and all claude skills symlinks

## Dependencies
None