### PR TITLE
fix(go): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -149,5 +149,5 @@ p6df::modules::go::prompt::lang() {
 ######################################################################
 p6df::modules::go::prompt::env() {
 
-  p6_return_words 'go' "$GOPATH"
+  p6_return_words 'go' '$GOPATH'
 }


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None