### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::go::deps()
-#
-#>
-######################################################################
 p6df::modules::go::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -16,11 +10,38 @@ p6df::modules::go::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::go::vscodes()
-#
-#>
+p6df::modules::go::langmgr::init() {
+
+  p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/syndbg/goenv" "go"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::go::home::symlinks() {
+
+  if p6_string_blank_NOT "$GOPATH"; then
+    p6_file_symlink "$P6_DFZ_SRC_DIR" "$GOPATH/src"
+  fi
+
+  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-go/share/.goenvrc" "$HOME/.goenvrc"
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/smallnest/goskills"  "$HOME/.claude/skills/goskills"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::go::langs() {
+
+  p6df::modules::go::langs::pull
+  p6df::modules::go::langs::nuke
+  p6df::modules::go::langs::install
+  p6df::modules::go::langs::packages
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::go::vscodes() {
 
@@ -31,12 +52,6 @@ p6df::modules::go::vscodes() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::go::vscodes::config()
-#
-#>
 ######################################################################
 p6df::modules::go::vscodes::config() {
 
@@ -65,24 +80,28 @@ EOF
 ######################################################################
 #<
 #
+# Function: p6df::modules::go::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::go::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::go::vscodes::config()
+#
+#>
+######################################################################
+#<
+#
 # Function: p6df::modules::go::home::symlinks()
 #
 #  Environment:	 GOPATH HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
 #>
-######################################################################
-p6df::modules::go::home::symlinks() {
-
-  if p6_string_blank_NOT "$GOPATH"; then
-    p6_file_symlink "$P6_DFZ_SRC_DIR" "$GOPATH/src"
-  fi
-
-  p6_file_symlink "$P6_DFZ_SRC_P6M7G8_DOTFILES_DIR/p6df-go/share/.goenvrc" "$HOME/.goenvrc"
-
-  p6_file_symlink "$P6_DFZ_SRC_DIR/smallnest/goskills"  "$HOME/.claude/skills/goskills"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #
@@ -90,31 +109,12 @@ p6df::modules::go::home::symlinks() {
 #
 #>
 ######################################################################
-p6df::modules::go::langs() {
-
-  p6df::modules::go::langs::pull
-  p6df::modules::go::langs::nuke
-  p6df::modules::go::langs::install
-  p6df::modules::go::langs::packages
-
-  p6_return_void
-}
-
-######################################################################
 #<
 #
 # Function: p6df::modules::go::langmgr::init()
 #
 #  Environment:	 P6_DFZ_SRC_DIR
 #>
-######################################################################
-p6df::modules::go::langmgr::init() {
-
-  p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/syndbg/goenv" "go"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::go::deps()
+#
+#>
+######################################################################
 p6df::modules::go::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6common
@@ -10,6 +16,13 @@ p6df::modules::go::deps() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::go::langmgr::init()
+#
+#  Environment:	 P6_DFZ_SRC_DIR
+#>
+######################################################################
 p6df::modules::go::langmgr::init() {
 
   p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/syndbg/goenv" "go"
@@ -17,6 +30,13 @@ p6df::modules::go::langmgr::init() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::go::home::symlinks()
+#
+#  Environment:	 GOPATH HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
+#>
 ######################################################################
 p6df::modules::go::home::symlinks() {
 
@@ -32,6 +52,12 @@ p6df::modules::go::home::symlinks() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::go::langs()
+#
+#>
+######################################################################
 p6df::modules::go::langs() {
 
   p6df::modules::go::langs::pull
@@ -43,6 +69,12 @@ p6df::modules::go::langs() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::go::vscodes()
+#
+#>
+######################################################################
 p6df::modules::go::vscodes() {
 
   # go
@@ -52,6 +84,12 @@ p6df::modules::go::vscodes() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::go::vscodes::config()
+#
+#>
 ######################################################################
 p6df::modules::go::vscodes::config() {
 
@@ -77,44 +115,6 @@ EOF
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::go::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::go::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::go::vscodes::config()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::go::home::symlinks()
-#
-#  Environment:	 GOPATH HOME P6_DFZ_SRC_DIR P6_DFZ_SRC_P6M7G8_DOTFILES_DIR
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::go::langs()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::go::langmgr::init()
-#
-#  Environment:	 P6_DFZ_SRC_DIR
-#>
 ######################################################################
 #<
 #


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None