### PR TITLE
refactor(go): update function signatures and rename prompt::env return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,13 @@ TODO: Add a short summary of this module.
 ##### p6df-go/init.zsh
 
 - `p6df::modules::go::deps()`
-- `p6df::modules::go::home::symlink()`
-- `p6df::modules::go::init(_module, dir)`
-  - Args:
-    - _module -
-    - dir -
+- `p6df::modules::go::home::symlinks()`
+- `p6df::modules::go::langmgr::init()`
 - `p6df::modules::go::langs()`
 - `p6df::modules::go::vscodes()`
 - `p6df::modules::go::vscodes::config()`
-- `str str = p6df::modules::go::prompt::env()`
 - `str str = p6df::modules::go::prompt::lang()`
+- `words go = p6df::modules::go::prompt::env()`
 
 #### p6df-go/lib
 

--- a/init.zsh
+++ b/init.zsh
@@ -139,10 +139,10 @@ p6df::modules::go::prompt::lang() {
 ######################################################################
 #<
 #
-# Function: words go $GOPATH = p6df::modules::go::prompt::env()
+# Function: words go = p6df::modules::go::prompt::env()
 #
 #  Returns:
-#	words - go $GOPATH
+#	words - go
 #
 #  Environment:	 GOPATH
 #>


### PR DESCRIPTION
**What:** Update function signatures with proper arg names and fix prompt::env return type declaration

**Why:** Normalizes function documentation to use consistent `words go` return type (removing `$GOPATH` from the type annotation) and renames `home::symlink` to `home::symlinks`

**Test plan:** Shell loads without errors; go prompt functions return expected values

**Dependencies:** none